### PR TITLE
chore: avatar has been added to Gametrails's navbar

### DIFF
--- a/src/components/Layout/Navbar/BigMenu.tsx
+++ b/src/components/Layout/Navbar/BigMenu.tsx
@@ -4,7 +4,8 @@ import { faArrowRightFromBracket } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import type { UserCookie } from '@/components/Login/LoginComponent/types';
 import {
-  LogoutItem, MenuItem, Premium, Username,
+  Avatar,
+  LogoutItem, MenuItem, Premium,
 } from './styles';
 
 export type Props = {
@@ -29,9 +30,7 @@ const BigMenu: FC<Props> = ({ userCookie, handleStripeCheckout }) => (
           <p>Crear Trail</p>
         </MenuItem>
         <MenuItem href={`/user/${userCookie?.id}`}>
-          <Username>
-            {userCookie?.username}
-          </Username>
+          <Avatar src={userCookie.avatar} alt="No hay imagen" />
         </MenuItem>
         {userCookie?.plan === 'STANDARD' && (
           <Premium onClick={handleStripeCheckout}>

--- a/src/components/Layout/Navbar/SmallMenu.tsx
+++ b/src/components/Layout/Navbar/SmallMenu.tsx
@@ -4,7 +4,8 @@ import { faArrowRightFromBracket } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import type { UserCookie } from '@/components/Login/LoginComponent/types';
 import {
-  LogoutItem, MenuItem, Premium, Username,
+  Avatar,
+  LogoutItem, MenuItem, Premium,
 } from './styles';
 
 export type Props = {
@@ -26,9 +27,7 @@ const SmallMenu: FC<Props> = ({ userCookie, handleStripeCheckout }) => (
           <h4>Crear Trail</h4>
         </MenuItem>
         <MenuItem href={`/user/${userCookie?.id}`}>
-          <Username>
-            {userCookie?.username}
-          </Username>
+          <Avatar src={userCookie.avatar} alt="No hay imagen" />
         </MenuItem>
         {userCookie?.plan === 'STANDARD' && (
           <Premium onClick={handleStripeCheckout}>

--- a/src/components/Layout/Navbar/styles.ts
+++ b/src/components/Layout/Navbar/styles.ts
@@ -28,6 +28,7 @@ export const ResponsiveNavbar = styled.div`
       flex-direction: row;
       align-items: center;
       height: auto;
+      gap:60px;
     }
 `;
 
@@ -150,9 +151,11 @@ export const User = styled.div`
     }
 `;
 
-export const Username = styled.p`
-    font-weight: 600;
-    color: ${({ theme }) => theme.nord.white0};
+export const Avatar = styled.img`
+    height: 60px;
+    width: 60px;
+    border-width: 1px;
+    border-radius: 100%;
 `;
 
 export const UserImage = styled(Image)`

--- a/src/components/UserDetails/UserData/styles.ts
+++ b/src/components/UserDetails/UserData/styles.ts
@@ -43,7 +43,7 @@ export const Container = styled.div`
         background-size: cover;
         background-repeat: no-repeat;
         background-position: center;
-        border-radius: 20px;
+        border-radius: 100%;
         box-shadow: 0 0 10px 0 ${({ theme }) => theme.nord.gray3};
     }
 


### PR DESCRIPTION
El nombre que aparecía antes en el navbar de GameTrail se ha sustituido por la foto de perfil "avatar" del usuario. 
También se ha cambiado la forma del avatar en la vista de detalles del usuario, para que sea redonda.
Por último, se ha aumentado la separación del menú de hamburguesa en la vista de móvil.

PC:


![image](https://user-images.githubusercontent.com/80246581/230306462-fb424897-0d12-49f9-9015-9c7a3091ab9a.png)


![image](https://user-images.githubusercontent.com/80246581/230306592-9c3706b4-5480-449b-83c6-d9bbb5014851.png)

Móvil:


![image](https://user-images.githubusercontent.com/80246581/230307078-760cb33c-e0c5-47f8-9bf4-a554074b4c18.png)


![image](https://user-images.githubusercontent.com/80246581/230307166-74e4c02a-9c35-464b-8519-e4b04ae0c22f.png)


![image](https://user-images.githubusercontent.com/80246581/230307399-f6b8c795-9185-4f75-89b2-6392615db3b7.png)


![image](https://user-images.githubusercontent.com/80246581/230307485-bcbe851e-ef13-4d62-abb6-76a71a9cf2c3.png)
